### PR TITLE
Update instructions for compiling the Elixir code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Clone IElixir repository and prepare the project
 ```Bash
 $ git clone https://github.com/pprzetacznik/IElixir.git
 $ mix deps.get
-$ mix deps.compile
 $ mix test
+$ MIX_ENV=prod mix compile
 ```
 
 #### Prepare `kernel.json` file


### PR DESCRIPTION
Since `start_script.sh` by default runs with MIX_ENV=prod, it seems the code needs to be compiled explicitly with MIX_ENV=prod as well. Explicitly compiling the dependencies before running `mix test`, however, isn't necessary.
