### PR TITLE
install_script.sh: Remove bashism

### DIFF
--- a/install_script.sh
+++ b/install_script.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p ~/.ipython/kernels/ielixir/
-START_SCRIPT_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/start_script.sh
+START_SCRIPT_PATH=$(cd `dirname "$0"` && pwd)/start_script.sh
 CONTENT='{
    "argv": ["'${START_SCRIPT_PATH}'", "{connection_file}"],
                 "display_name": "ielixir",


### PR DESCRIPTION
- Replaced `${BASH_SOURCE[0]}` by `$0`.
- `sh install_script.sh` failed in Ubuntu,
  because the default shell isn't `bash`.
