### PR TITLE
Fix doctest for execute_code

### DIFF
--- a/lib/ielixir/sandbox.ex
+++ b/lib/ielixir/sandbox.ex
@@ -100,7 +100,7 @@ defmodule IElixir.Sandbox do
       {:error, "ArgumentError", ["** (ArgumentError) \"argument error\""]}
 
       iex> IElixir.Sandbox.execute_code(%{"code" => "\"a\" + 5"})
-      {:error, "ArithmeticError", ["** %ArithmeticError{}"]}
+      {:error, "ArithmeticError", ["** %ArithmeticError{message: \"bad argument in arithmetic expression\"}"]}
 
   """
   @spec execute_code(map) :: execution_response


### PR DESCRIPTION
I suspect the change is caused by a new version of Elixir.
