### PR TITLE
Make IElixir tolerate multiple UUIDs

### DIFF
--- a/lib/ielixir/socket/shell.ex
+++ b/lib/ielixir/socket/shell.ex
@@ -172,4 +172,3 @@ defmodule IElixir.Socket.Shell do
     Message.send_message(sock, message, "history_reply", content)
   end
 end
-


### PR DESCRIPTION
There can be multiple identity blobs in a message, see here:

https://jupyter-client.readthedocs.io/en/latest/messaging.html#the-wire-protocol
