### PR TITLE
Fix syntax highlight of Octal numbers

### DIFF
--- a/resources/ielixir/kernel.js
+++ b/resources/ielixir/kernel.js
@@ -126,7 +126,7 @@ var enableElixirMode = function (CodeMirror) {
           stream.eatWhile(/[\da-fA-F]/);
         } else if (stream.eat('b')) {
           stream.eatWhile(/[01]/);
-        } else {
+        } else if (stream.eat('o')) {
           stream.eatWhile(/[0-7]/);
         }
         return 'number';


### PR DESCRIPTION
 - There was a small problem with Octal number highlighting, fixed it
 - I will try to submit the patch to codemirror elixir project as well