### PR TITLE
Stuff I changed to get a clean run on Elixir 1.7.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule IElixir.Mixfile do
      version: @version,
      source_url: "https://github.com/pprzetacznik/IElixir",
      name: "IElixir",
-     elixir: ">= 1.1.0 and < 1.7.0",
+     elixir: ">= 1.5.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      consolidate_protocols: false,
@@ -18,7 +18,12 @@ defmodule IElixir.Mixfile do
      """,
      package: package(),
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]]
+     preferred_cli_env: [
+       coveralls: :test,
+       "coveralls.detail": :test,
+       "coveralls.post": :test,
+       "coveralls.html": :test
+     ]]
   end
 
   def application do

--- a/test/boyle_test.exs
+++ b/test/boyle_test.exs
@@ -72,12 +72,13 @@ defmodule IElixir.BoyleTest do
       rescue
         error -> error
       end
+
     assert error == %UndefinedFunctionError{
       arity: 1,
-      exports: nil,
       function: :number_to_currency,
       module: Number.Currency,
-      reason: nil}
+      reason: nil,
+    }
   end
 
   defp assert_that_number_module_works_properly() do


### PR DESCRIPTION
get rid of warning on quoted atom, and update structure of UndefinedFunctionerror in boyle_test. Also remove restiction that Elixir must be pre-1.7