### PR TITLE
Support stderr

### DIFF
--- a/lib/ielixir/boyle.ex
+++ b/lib/ielixir/boyle.ex
@@ -350,14 +350,6 @@ defmodule Boyle do
     File.write!(Path.join(env_path, "deps.lock"), "[]")
   end
 
-  defp create_deps_lock_file_old(env_path) do
-    File.write!(Path.join(env_path, "deps.lock"), """
-    [
-      {:matrex, github: "versilov/matrex"},
-      {:ielixir, github: "pprzetacznik/ielixir"}
-    ]
-    """)
-  end
 
   defp purge(modules) do
     Enum.each(modules, fn module ->

--- a/lib/ielixir/capture_io.ex
+++ b/lib/ielixir/capture_io.ex
@@ -1,0 +1,44 @@
+defmodule IElixir.CaptureIO do
+
+  def capture(fun) do
+    { { result, error_stream }, output_stream } = capture_stdout(fn ->
+      capture_stderr(fun)
+    end)
+    { result, output_stream, error_stream }
+  end
+
+  defp capture_stdout(fun) do
+    original_gl = Process.group_leader()
+    {:ok, capture_gl} = StringIO.open("", capture_prompt: true)
+    try do
+      Process.group_leader(self(), capture_gl)
+      result = fun.()
+      { :ok, { _, output }} = StringIO.close(capture_gl)
+      { result, output }
+    after
+      Process.group_leader(self(), original_gl)
+    end
+  end
+
+  defp capture_stderr(fun) do
+    original_err = Process.whereis(:standard_error)
+    {:ok, capture_err} = StringIO.open("", capture_prompt: true)
+    Process.unregister(:standard_error)
+    try do
+      Process.register(capture_err, :standard_error)
+      result = fun.()
+      { _, output } = StringIO.contents(capture_err)
+      { result, output }
+    rescue
+      error ->
+        raise(error)
+    else
+      result ->
+        Process.unregister(:standard_error)
+        StringIO.close(capture_err)
+        Process.register(original_err, :standard_error)
+        result
+    end
+  end
+
+end

--- a/lib/ielixir/history_entry.ex
+++ b/lib/ielixir/history_entry.ex
@@ -6,7 +6,6 @@ defmodule IElixir.HistoryEntry do
     field :output
     field :session
     field :line_number, :integer
-    timestamps
+    timestamps()
   end
 end
-

--- a/lib/ielixir/message.ex
+++ b/lib/ielixir/message.ex
@@ -74,16 +74,16 @@ defmodule IElixir.Message do
   @doc false
   def send_message(sock, message, message_type, content) do
     new_message = %{message |
-      "header": %{
+      header: %{
         "msg_id" => :uuid.uuid_to_string(:uuid.get_v4(), :binary_standard),
         "username" => "ielixir_kernel",
         "session" => message.header["session"],
         "msg_type" => message_type,
         "version" => "5.0",
       },
-      "parent_header": message.header,
-      "metadata": %{},
-      "content": content,
+      parent_header: message.header,
+      metadata: %{},
+      content: content,
     }
     send_all(sock, encode(new_message))
   end

--- a/lib/ielixir/queries.ex
+++ b/lib/ielixir/queries.ex
@@ -32,12 +32,12 @@ defmodule IElixir.Queries do
 
   ### Example
 
-      iex> {:ok, _result, output, line_number} = IElixir.Sandbox.execute_code(%{"code" => "a=10"})
-      {:ok, "10", "", 1}
+      iex> {:ok, _result, output, "", line_number} = IElixir.Sandbox.execute_code(%{"code" => "a=10"})
+      {:ok, "10", "", "", 1}
       iex> IElixir.Queries.insert("cd8ad0b7-09fa-49b7-be7d-987845b4be63", line_number, "a=10", output)
       :ok
-      iex> {:ok, _result, output, line_number} = IElixir.Sandbox.execute_code(%{"code" => "IO.puts(\"aaa\")"})
-      {:ok, ":ok", "aaa\n", 2}
+      iex> {:ok, _result, output, "", line_number} = IElixir.Sandbox.execute_code(%{"code" => "IO.puts(\"aaa\")"})
+      {:ok, ":ok", "aaa\n", "", 2}
       iex> IElixir.Queries.insert("cd8ad0b7-09fa-49b7-be7d-987845b4be63", line_number, "IO.puts(\"aaa\")", output)
       :ok
       iex> IElixir.Queries.get_entries_list(false)
@@ -58,4 +58,3 @@ defmodule IElixir.Queries do
              end)
   end
 end
-

--- a/lib/ielixir/socket/control.ex
+++ b/lib/ielixir/socket/control.ex
@@ -29,7 +29,7 @@ defmodule IElixir.Socket.Control do
   end
 
   defp process("shutdown_request", message, sock) do
-    Message.send_message(sock, message, "shutdown_reply", %{"restart": true})
+    Message.send_message(sock, message, "shutdown_reply", %{ restart: true})
     Logger.info("Stopping application")
     :erlzmq.close(sock)
     Application.stop(:ielixir)
@@ -38,4 +38,3 @@ defmodule IElixir.Socket.Control do
     Logger.debug("Got unexpected message :: #{inspect message}\n")
   end
 end
-

--- a/lib/ielixir/socket/iopub.ex
+++ b/lib/ielixir/socket/iopub.ex
@@ -46,8 +46,8 @@ defmodule IElixir.Socket.IOPub do
   @doc """
   Send stream message. This is used for sending output of code execution.
   """
-  def send_stream(message, text) do
-    GenServer.cast(IOPub, {:send_stream, message, text})
+  def send_stream(message, text, stream_name \\ "stdout") do
+    GenServer.cast(IOPub, {:send_stream, message, text, stream_name})
   end
 
   @doc """
@@ -80,10 +80,10 @@ defmodule IElixir.Socket.IOPub do
     {:noreply, sock}
   end
 
-  def handle_cast({:send_stream, message, text}, sock) do
+  def handle_cast({:send_stream, message, text, stream_name}, sock) do
     content = %{
        text: text,
-       name: "stdout",
+       name: stream_name,
     }
     Message.send_message(sock, message, "stream", content)
     {:noreply, sock}

--- a/lib/ielixir/socket/shell.ex
+++ b/lib/ielixir/socket/shell.ex
@@ -138,6 +138,7 @@ defmodule IElixir.Socket.Shell do
       message: message,
       sock:    sock,
       count:   count,
+      silent:  message.content["silent"],
     }
   end
 
@@ -149,10 +150,15 @@ defmodule IElixir.Socket.Shell do
       message:   message,
       sock:      sock,
       count:     count,
+      silent:    message.content["silent"],
     }
   end
 
   defp publish_output(response = %{ status: :error }) do
+    response
+  end
+
+  defp publish_output(response = %{ silent: true }) do
     response
   end
 
@@ -178,11 +184,13 @@ defmodule IElixir.Socket.Shell do
     response
   end
 
-  # todo: this seems the wrong way around. shouldn't silent mean no output?
+  # I thing the originsl was wrong here: it was "or-ing" witn the silent flag
+
   defp publish_execute_response(response = %{ result: "" }) do
-    if response.message.content["silent"] == true do
-      IOPub.send_execute_result(response.message, {inspect(""), response.count})
-    end
+    response
+  end
+
+  defp publish_execute_response(response = %{ silent: true }) do
     response
   end
 
@@ -196,6 +204,10 @@ defmodule IElixir.Socket.Shell do
   end
 
   defp update_history(response = %{ status: :error }) do
+    response
+  end
+
+  defp update_history(response = %{ silent: true }) do
     response
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule IElixir.Mixfile do
      version: @version,
      source_url: "https://github.com/pprzetacznik/IElixir",
      name: "IElixir",
-     elixir: ">= 1.1.0 and < 1.7.0",
+     elixir: ">= 1.5.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      consolidate_protocols: false,
@@ -18,7 +18,12 @@ defmodule IElixir.Mixfile do
      """,
      package: package(),
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]]
+     preferred_cli_env: [
+       coveralls: :test,
+       "coveralls.detail": :test,
+       "coveralls.post": :test,
+       "coveralls.html": :test
+     ]]
   end
 
   def application do

--- a/resources/example.ipynb
+++ b/resources/example.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "# IElixir - Elixir kernel for Jupyter Project\n",
     "\n",
@@ -49,33 +47,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "3"
+      "text/html": [
+       "<b>bold</b> and <em>emphasised</em>\n"
       ]
      },
-     "execution_count": 1,
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       ":\"this is raw html\""
+      ]
+     },
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "1 + 2"
+    "IO.puts \"<b>bold</b> and <em>emphasised</em>\"\n",
+    ":\"this is raw html\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "25\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -88,15 +99,13 @@
     }
    ],
    "source": [
-    "5 * 5"
+    "IO.inspect 5 * 5"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -116,9 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -138,9 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -160,9 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -182,9 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -204,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -226,9 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -248,9 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -270,9 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -292,9 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -314,9 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -343,9 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -365,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -387,9 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -409,9 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -431,9 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -454,7 +433,6 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -476,9 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -505,9 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -527,9 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -549,9 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -571,9 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -593,9 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -622,9 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -644,9 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -666,9 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -696,9 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -718,9 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -740,9 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -762,9 +716,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -791,9 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -813,9 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -835,9 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -857,9 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -879,9 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -901,9 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -923,9 +863,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -945,9 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -976,9 +912,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -998,9 +932,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1020,9 +952,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1042,9 +972,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1064,9 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1086,9 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1108,9 +1032,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "ArgumentError",
@@ -1128,9 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1150,9 +1070,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1172,9 +1090,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1201,9 +1117,7 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1223,9 +1137,7 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1245,9 +1157,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1267,9 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1289,9 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1311,9 +1217,7 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1333,9 +1237,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1362,9 +1264,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1384,9 +1284,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1406,9 +1304,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1428,9 +1324,7 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1450,9 +1344,7 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1479,9 +1371,7 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1502,7 +1392,6 @@
    "cell_type": "code",
    "execution_count": 63,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -1533,9 +1422,7 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1559,9 +1446,7 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1582,7 +1467,6 @@
    "cell_type": "code",
    "execution_count": 66,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -1605,9 +1489,7 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1627,9 +1509,7 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1650,7 +1530,6 @@
    "cell_type": "code",
    "execution_count": 69,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -1673,9 +1552,7 @@
   {
    "cell_type": "code",
    "execution_count": 70,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1697,9 +1574,7 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1763,7 +1638,6 @@
    "cell_type": "code",
    "execution_count": 72,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -1832,7 +1706,6 @@
    "cell_type": "code",
    "execution_count": 73,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -1854,9 +1727,7 @@
   {
    "cell_type": "code",
    "execution_count": 74,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1893,20 +1764,20 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ielixir",
+   "display_name": "Elixir",
    "language": "Elixir",
    "name": "ielixir"
   },
   "language_info": {
-   "codemirror_mode": "erlang",
+   "codemirror_mode": "elixir",
    "file_extension": "ex",
    "mimetype": "text/x-elixir",
    "name": "elixir",
    "nbconvert_exporter": "",
-   "pygments_lexer": "pygments.lexers.erlang.ElixirLexer",
-   "version": "#Version<1.1.0-dev>"
+   "pygments_lexer": "elixir",
+   "version": "1.7.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/resources/example.ipynb
+++ b/resources/example.ipynb
@@ -47,31 +47,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<b>bold</b> and <em>emphasised</em>\n"
+       "<b>bold</b> &amp; and <em>emphasised</em>\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       ":\"this is raw html\""
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "IO.puts \"<b>bold</b> and <em>emphasised</em>\"\n",
+    "IO.puts \"<b>bold</b> &amp; and <em>emphasised</em>\"\n",
     ":\"this is raw html\""
    ]
   },

--- a/resources/example.ipynb
+++ b/resources/example.ipynb
@@ -47,22 +47,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<b>bold</b> &amp; and <em>emphasised</em>\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "ename": "MatchError",
+     "evalue": "1",
+     "output_type": "error",
+     "traceback": [
+      "** %MatchError{term: {1, 2}}"
+     ]
     }
    ],
    "source": [
-    "IO.puts \"<b>bold</b> &amp; and <em>emphasised</em>\"\n",
-    ":\"this is raw html\""
+    "{a} = {1,2}"
    ]
   },
   {

--- a/test/boyle_test.exs
+++ b/test/boyle_test.exs
@@ -72,12 +72,13 @@ defmodule IElixir.BoyleTest do
       rescue
         error -> error
       end
+
     assert error == %UndefinedFunctionError{
       arity: 1,
-      exports: nil,
       function: :number_to_currency,
       module: Number.Currency,
-      reason: nil}
+      reason: nil,
+    }
   end
 
   defp assert_that_number_module_works_properly() do

--- a/test/capture_io_test.exs
+++ b/test/capture_io_test.exs
@@ -1,0 +1,30 @@
+defmodule IElixir.CaptureIOTest do
+
+  use ExUnit.Case
+
+  alias IElixir.CaptureIO, as: CIO
+
+  test "correct value for function result is returned" do
+    { "wombat", _, _ } = CIO.capture(fn -> "wombat" end)
+  end
+
+  test "stdout is passed back" do
+    { _, "one\ntwo\n", _ } = CIO.capture(fn -> IO.puts("one"); IO.puts("two") end)
+  end
+
+  test "stderr is passed back" do
+    { _, _, "err1\nerr2\n" } = CIO.capture(fn -> IO.puts(:stderr, "err1"); IO.puts(:stderr, "err2") end)
+  end
+
+  test "result, stdout, and stderr are returned" do
+    func = fn ->
+      IO.puts "one"
+      IO.puts :stderr, "err1"
+      IO.puts "two"
+      IO.puts :stderr, "err2"
+      "wombat" |> String.upcase
+    end
+    { "WOMBAT", "one\ntwo\n", "err1\nerr2\n" } = CIO.capture(func)
+  end
+
+end

--- a/test/sandbox_test.exs
+++ b/test/sandbox_test.exs
@@ -15,9 +15,9 @@ defmodule IElixir.SandboxTest do
   end
 
   test "lambdas" do
-    {:ok, _result, output, line_number} = Sandbox.execute_code(prepare_request("function = fn x -> 2*x end"))
-    assert {"", 1} == {output, line_number}
-    assert {:ok, "4", "", 2} == Sandbox.execute_code(prepare_request("function.(2)"))
+    {:ok, _result, stdout, stderr, line_number} = Sandbox.execute_code(prepare_request("function = fn x -> 2*x end"))
+    assert {"", "", 1} == {stdout, stderr, line_number}
+    assert {:ok, "4", "", "", 2} == Sandbox.execute_code(prepare_request("function.(2)"))
   end
 
   # now handled in shell.ex

--- a/test/sandbox_test.exs
+++ b/test/sandbox_test.exs
@@ -20,10 +20,11 @@ defmodule IElixir.SandboxTest do
     assert {:ok, "4", "", 2} == Sandbox.execute_code(prepare_request("function.(2)"))
   end
 
-  test "IEx.Helpers methods in console" do
-    {:ok, result, _output, line_number} = Sandbox.execute_code(prepare_request("h()"))
-    assert {"", 1} == {result, line_number}
-  end
+  # now handled in shell.ex
+  # test "IEx.Helpers methods in console" do
+  #   {:ok, result, _output, line_number} = Sandbox.execute_code(prepare_request("h()"))
+  #   assert {"", 1} == {result, line_number}
+  # end
 
   defp prepare_request(code) do
     %{


### PR DESCRIPTION
Refactored the capture code, so we now grab stderr and stdout, passing stderr back to Juptyer in a separate stream.

Unfortunately, as a PR, this change relies on the additional refactorings done  when adding HTML support, so you probably  want to merge that one first.